### PR TITLE
Polishing the init script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-ocaml = {path = "../ocaml-rs", version = "^1.0.0-beta"}
+ocaml = {version = "^1.0.0-beta"}
 
 [build-dependencies]
 ocaml-build = {version = "^1.0.0-beta"}

--- a/dune-project
+++ b/dune-project
@@ -1,10 +1,10 @@
 (lang dune 2.0)
-(name dedupe-ml-rs)
+(name ocaml-rust-starter)
 
 (generate_opam_files true)
 
 (package
- (name dedupe-ml-rs)
+ (name ocaml-rust-starter)
  (synopsis "FIXME:")
  (description "FIXME:")
  (depends

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,13 @@
 (lang dune 2.0)
+(name dedupe-ml-rs)
 
-(name ocaml-rust-starter)
+(generate_opam_files true)
+
+(package
+ (name dedupe-ml-rs)
+ (synopsis "FIXME:")
+ (description "FIXME:")
+ (depends
+  (ocaml (>= "4.03.0"))
+  (dune (>= "1.5"))
+  conf-rust-2018))

--- a/init.sh
+++ b/init.sh
@@ -1,14 +1,43 @@
-name=$1
-public_name=${2-$name}
+#!/bin/sh -eu
+
+usage() {
+  cat >&2 <<EOF
+usage: init NAME PUBLIC_NAME
+Note that NAME will be the library name and thus must be non-empty and composed only of the following
+characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
+
+Setup a project
+EOF
+  exit 1
+}
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  usage
+fi
+
+case $(uname | tr '[:upper:]' '[:lower:]') in
+linux*)
+  OS_NAME=linux
+  ;;
+darwin*)
+  OS_NAME=osx
+  ;;
+*)
+  OS_NAME=notset
+  ;;
+esac
 
 replace() {
-  is_gnu=`sed --version`
-  if [ $? -ne 0 ]; then
-    sed -i "" $@
+  if [[ "$OS_NAME" = "osx" ]]; then
+    sed -i '' $@
   else
     sed -i $@
   fi
 }
+
+## Replace hyphens in $name so that we have a valid library name
+name="$(echo "$1" | sed 's/-/_/g')"
+public_name="${2-$1}"
 
 replace 's/ocaml-rust-starter/'"$public_name"'/g' dune-project
 replace 's/ocaml_rust_starter/'"$name"'/g' src/dune
@@ -16,9 +45,20 @@ replace 's/ocaml-rust-starter/'"$public_name"'/g' src/dune
 replace 's/ocaml-rust-starter/'"$public_name"'/g' test/dune
 replace 's/ocaml-rust-starter/'"$public_name"'/g' Cargo.toml
 replace 's/ocaml_rust_starter/'"$name"'/g' build.rs
-printf "# $public_name\n" > README.md
+printf "# $public_name\n" >README.md
 mv ocaml-rust-starter.opam $public_name.opam
 mv src/ocaml_rust_starter.ml src/$name.ml || :
 mv src/ocaml_rust_starter.mli src/$name.mli
-echo "" > test/test.ml
-rm init.sh
+echo "" >test/test.ml
+
+while true; do
+  read -p "Cleaning up - remove init.sh (y/n)? " -r yn
+  case "${yn}" in
+  [Yy]*)
+    rm init.sh
+    break
+    ;;
+  [Nn]*) exit ;;
+  *) echo "" ;;
+  esac
+done

--- a/init.sh
+++ b/init.sh
@@ -46,7 +46,7 @@ replace 's/ocaml-rust-starter/'"$public_name"'/g' test/dune
 replace 's/ocaml-rust-starter/'"$public_name"'/g' Cargo.toml
 replace 's/ocaml_rust_starter/'"$name"'/g' build.rs
 printf "# $public_name\n" >README.md
-mv ocaml-rust-starter.opam $public_name.opam
+rm ocaml-rust-starter.opam ## regenerate opam file from dune-project
 mv src/ocaml_rust_starter.ml src/$name.ml || :
 mv src/ocaml_rust_starter.mli src/$name.mli
 echo "" >test/test.ml


### PR DESCRIPTION
- Script checks for params and shows usage
- Friendlier checking for the platform for setting the correct usage of `sed -i`
- Current script leaves behind original author etc. in the opam file - switch instead to generating the opam file

- Additionally, fixes a hardcoded path in `Cargo.toml`

// @zshipko 