### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ ocaml = {version = "^1.0.0-beta"}
 ocaml-build = {version = "^1.0.0-beta"}
 
 # Or use the development version:
-# ocaml = {git = "git://github.com/zshipko/ocaml-rs"}
+# ocaml = {git = "https://github.com/zshipko/ocaml-rs.git"}


### PR DESCRIPTION
Github no longer supports this access protocol.